### PR TITLE
fix: correct calulated→calculated typo in visitor output message

### DIFF
--- a/behavioral/visitor/visitor.go
+++ b/behavioral/visitor/visitor.go
@@ -71,7 +71,7 @@ func main() {
 	}
 
 	fmt.Println(
-		"Next release is calulated in",
+		"Next release is calculated in",
 		storyPoints.Sum,
 		"story points",
 	)


### PR DESCRIPTION
Correct a typo in the visitor pattern example output message: `calulated` → `calculated`.

**Change**: 1 file, 1 line
**Before**: `"Next release is calulated in"`  
**After**: `"Next release is calculated in"`

The typo is in a `fmt.Println` user-facing output string. Fixes a simple spelling error.